### PR TITLE
Correction of file structure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,5 +22,3 @@ npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
 
-# md contents
-/src/contents


### PR DESCRIPTION
.ginignoreに記載した`/src/contents`がローカルの`master`で消えてしまったので修正する